### PR TITLE
simplify the cmakelists.txt and package.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ generated
 # other:
 widgets.html
 
+# clion project files 
+.idea/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,9 @@ cmake_minimum_required(VERSION 2.8.3)
 project(vrep_ros_interface)
 
 set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG")
+#set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG")
 
-set(CATKIN_DEPS
+set(PKG_DEPS
   roscpp
   rosconsole
   cv_bridge
@@ -28,16 +28,14 @@ set(CATKIN_DEPS
   trajectory_msgs
   visualization_msgs)
 
-find_package(catkin REQUIRED COMPONENTS ${CATKIN_DEPS}
+find_package(catkin REQUIRED COMPONENTS ${PKG_DEPS}
 )
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/")
 find_package(VREP REQUIRED)
-message(STATUS "vrep:" ${VREP_FOUND})
-message(STATUS "vrep:" ${VREP_INCLUDE})
-message(STATUS "vrep:" ${VREP_COMMON})
+
 catkin_package(
-    CATKIN_DEPENDS
+    CATKIN_DEPENDS ${PKG_DEPS}
 )
 
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/generated)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,26 +4,52 @@ project(vrep_ros_interface)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG")
 
-find_package(catkin REQUIRED COMPONENTS
-  roscpp rosmsg image_transport tf cv_bridge
+set(CATKIN_DEPS
+  roscpp
+  rosconsole
+  cv_bridge
+  image_transport
+  tf brics_actuator
+  roslib
+  brics_actuator
+  actionlib_msgs
+  control_msgs
+  diagnostic_msgs
+  geometry_msgs
+  map_msgs
+  nav_msgs
+  pcl_msgs
+  sensor_msgs
+  shape_msgs
+  std_msgs
+  tf2_geometry_msgs
+  tf2_msgs
+  tf2_sensor_msgs
+  trajectory_msgs
+  visualization_msgs)
+
+find_package(catkin REQUIRED COMPONENTS ${CATKIN_DEPS}
 )
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/")
 find_package(VREP REQUIRED)
-
+message(STATUS "vrep:" ${VREP_FOUND})
+message(STATUS "vrep:" ${VREP_INCLUDE})
+message(STATUS "vrep:" ${VREP_COMMON})
 catkin_package(
-    CATKIN_DEPENDS roscpp rosconsole cv_bridge image_transport tf brics_actuator roslib actionlib_msgs control_msgs diagnostic_msgs geometry_msgs map_msgs nav_msgs pcl_msgs sensor_msgs shape_msgs std_msgs tf2_geometry_msgs tf2_msgs tf2_sensor_msgs trajectory_msgs visualization_msgs
+    CATKIN_DEPENDS
 )
 
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/generated)
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doc)
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/external)
-include_directories(${CMAKE_CURRENT_BINARY_DIR}/generated)
-include_directories(${catkin_INCLUDE_DIRS})
-include_directories(${VREP_INCLUDE})
-include_directories(${VREP_COMMON})
+include_directories(
+  ${CMAKE_CURRENT_SOURCE_DIR}/include
+  ${CMAKE_CURRENT_SOURCE_DIR}/external
+  ${CMAKE_CURRENT_BINARY_DIR}/generated
+  ${catkin_INCLUDE_DIRS}
+  ${VREP_INCLUDE}
+  ${VREP_COMMON})
 
 link_directories("/opt/ros/fuerte/lib")
 link_directories("/opt/ros/groovy/lib")
@@ -55,16 +81,8 @@ add_library(v_repExtRosInterface ${SOURCES})
 add_dependencies(v_repExtRosInterface ${catkin_EXPORTED_TARGETS} generate_ros_code)
 target_link_libraries(v_repExtRosInterface
     pthread
-    dl
-    roslib
-    rosconsole
-    rostime
-    rospack
-    roscpp_serialization
-    roscpp
-    tf
-    image_transport
-    boost_system
     ${catkin_LIBRARIES}
     ${VREP_LIBRARIES}
 )
+## install the library to VREP_ROOT folder
+install(TARGETS v_repExtRosInterface DESTINATION ${VREP_ROOT})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,61 +1,50 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.0)
 project(vrep_ros_interface)
-
 set(CMAKE_CXX_STANDARD 11)
-#set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG")
 
 set(PKG_DEPS
-  roscpp
-  rosconsole
-  cv_bridge
-  image_transport
-  tf brics_actuator
-  roslib
-  brics_actuator
-  actionlib_msgs
-  control_msgs
-  diagnostic_msgs
-  geometry_msgs
-  map_msgs
-  nav_msgs
-  pcl_msgs
-  sensor_msgs
-  shape_msgs
-  std_msgs
-  tf2_geometry_msgs
-  tf2_msgs
-  tf2_sensor_msgs
-  trajectory_msgs
-  visualization_msgs)
+    roscpp
+    rosconsole
+    cv_bridge
+    image_transport
+    tf brics_actuator
+    roslib
+    brics_actuator
+    actionlib_msgs
+    control_msgs
+    diagnostic_msgs
+    geometry_msgs
+    map_msgs
+    nav_msgs
+    pcl_msgs
+    sensor_msgs
+    shape_msgs
+    std_msgs
+    tf2_geometry_msgs
+    tf2_msgs
+    tf2_sensor_msgs
+    trajectory_msgs
+    visualization_msgs)
 
-find_package(catkin REQUIRED COMPONENTS ${PKG_DEPS}
-)
+find_package(catkin REQUIRED COMPONENTS ${PKG_DEPS})
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/")
+
 find_package(VREP REQUIRED)
 
 catkin_package(
-    CATKIN_DEPENDS ${PKG_DEPS}
-)
+    CATKIN_DEPENDS ${PKG_DEPS})
 
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/generated)
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doc)
 
 include_directories(
-  ${CMAKE_CURRENT_SOURCE_DIR}/include
-  ${CMAKE_CURRENT_SOURCE_DIR}/external
-  ${CMAKE_CURRENT_BINARY_DIR}/generated
-  ${catkin_INCLUDE_DIRS}
-  ${VREP_INCLUDE}
-  ${VREP_COMMON})
-
-link_directories("/opt/ros/fuerte/lib")
-link_directories("/opt/ros/groovy/lib")
-link_directories("/opt/ros/hydro/lib")
-link_directories("/opt/ros/indigo/lib")
-link_directories("/opt/ros/jade/lib")
-link_directories("/opt/ros/kinetic/lib")
-link_directories("/opt/ros/melodic/lib")
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/external
+    ${CMAKE_CURRENT_BINARY_DIR}/generated
+    ${catkin_INCLUDE_DIRS}
+    ${VREP_INCLUDE}
+    ${VREP_COMMON})
 
 set(generatedFiles)
 file(GLOB templateFiles RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/templates/ ${CMAKE_CURRENT_SOURCE_DIR}/templates/*)
@@ -64,23 +53,32 @@ foreach(templateFile ${templateFiles})
     set(generatedFiles ${generatedFiles} "${CMAKE_CURRENT_BINARY_DIR}/generated/${templateFile}")
 endforeach()
 add_custom_target(generate_ros_code DEPENDS ${generatedFiles})
+
 vrep_generate_stubs(${CMAKE_CURRENT_BINARY_DIR}/generated XML_FILE ${CMAKE_CURRENT_SOURCE_DIR}/meta/callbacks.xml LUA_FILE ${CMAKE_CURRENT_SOURCE_DIR}/simExtRosInterface.lua)
 
 set(SOURCES
     src/vrep_ros_interface.cpp
+    src/ros_msg_builtin_io.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/external/v_repPlusPlus/Plugin.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/generated/stubs.cpp
-    src/ros_msg_builtin_io.cpp
-    ${VREP_EXPORTED_SOURCES}
+    ${VREP_EXPORTED_SOURCES}  ## only for v_repLib.cpp in vrep, found by FindVREP.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/generated/ros_msg_io.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/generated/ros_srv_io.cpp
 )
-add_library(v_repExtRosInterface ${SOURCES})
-add_dependencies(v_repExtRosInterface ${catkin_EXPORTED_TARGETS} generate_ros_code)
+
+## create the library
+add_library(v_repExtRosInterface
+    ${SOURCES})
+add_dependencies(v_repExtRosInterface generate_ros_code)
+## link the library
 target_link_libraries(v_repExtRosInterface
-    pthread
     ${catkin_LIBRARIES}
-    ${VREP_LIBRARIES}
-)
+    ${VREP_LIBRARIES})
+## This will produce the library directly in vrep root folder. The default folder
+## for the libv_repExtRosInterface.so file will not be devel/lib anymore.
+set_target_properties(v_repExtRosInterface
+    PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${VREP_ROOT})
+
 ## install the library to VREP_ROOT folder
-install(TARGETS v_repExtRosInterface DESTINATION ${VREP_ROOT})
+## this command will install the generated library to the vrep root folder no matter where the library is generated.
+#install(TARGETS v_repExtRosInterface DESTINATION ${VREP_ROOT})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,8 +33,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/mo
 
 find_package(VREP REQUIRED)
 
-catkin_package(
-    CATKIN_DEPENDS ${PKG_DEPS})
+catkin_package(CATKIN_DEPENDS ${PKG_DEPS})
 
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/generated)
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doc)
@@ -67,11 +66,9 @@ set(SOURCES
     ${CMAKE_CURRENT_BINARY_DIR}/generated/ros_srv_io.cpp
 )
 
-## create the library
 add_library(v_repExtRosInterface
     ${SOURCES})
 add_dependencies(v_repExtRosInterface generate_ros_code)
-## link the library
 target_link_libraries(v_repExtRosInterface
     ${catkin_LIBRARIES}
     ${VREP_LIBRARIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,8 @@ set(PKG_DEPS
     rosconsole
     cv_bridge
     image_transport
-    tf brics_actuator
+    tf
+    brics_actuator
     roslib
     brics_actuator
     actionlib_msgs
@@ -81,4 +82,4 @@ set_target_properties(v_repExtRosInterface
 
 ## install the library to VREP_ROOT folder
 ## this command will install the generated library to the vrep root folder no matter where the library is generated.
-#install(TARGETS v_repExtRosInterface DESTINATION ${VREP_ROOT})
+## install(TARGETS v_repExtRosInterface DESTINATION ${VREP_ROOT})

--- a/package.xml
+++ b/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="2">
   <name>vrep_ros_interface</name>
   <description>V-REP plugin for ROS interface</description>
   <maintainer email="marc@coppeliarobotics.com">Marc</maintainer>
@@ -7,51 +7,28 @@
   <license>BSD2</license>
   <url>http://www.coppeliarobotics.com</url>
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>rosmsg</build_depend>
-  <build_depend>libopencv-dev</build_depend>
-  <build_depend>cv_bridge</build_depend>
-  <build_depend>image_transport</build_depend>
-  <build_depend>tf</build_depend>
-  <build_depend>actionlib_msgs</build_depend>
-  <build_depend>control_msgs</build_depend>
-  <build_depend>diagnostic_msgs</build_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>map_msgs</build_depend>
-  <build_depend>nav_msgs</build_depend>
-  <build_depend>pcl_msgs</build_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <build_depend>shape_msgs</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>tf2_geometry_msgs</build_depend>
-  <build_depend>tf2_msgs</build_depend>
-  <build_depend>tf2_sensor_msgs</build_depend>
-  <build_depend>trajectory_msgs</build_depend>
-  <build_depend>visualization_msgs</build_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>libopencv-dev</run_depend>
-  <run_depend>image_transport</run_depend>
-  <run_depend>tf</run_depend>
-  <run_depend>brics_actuator</run_depend>
-  <run_depend>cv_bridge</run_depend>
-  <run_depend>perception_pcl</run_depend>
-  <run_depend>rosconsole</run_depend>
-  <run_depend>roslib</run_depend>
-  <run_depend>actionlib_msgs</run_depend>
-  <run_depend>control_msgs</run_depend>
-  <run_depend>diagnostic_msgs</run_depend>
-  <run_depend>geometry_msgs</run_depend>
-  <run_depend>map_msgs</run_depend>
-  <run_depend>nav_msgs</run_depend>
-  <run_depend>pcl_msgs</run_depend>
-  <run_depend>sensor_msgs</run_depend>
-  <run_depend>shape_msgs</run_depend>
-  <run_depend>std_msgs</run_depend>
-  <run_depend>tf2_geometry_msgs</run_depend>
-  <run_depend>tf2_msgs</run_depend>
-  <run_depend>tf2_sensor_msgs</run_depend>
-  <run_depend>trajectory_msgs</run_depend>
-  <run_depend>visualization_msgs</run_depend>
+  <depend>roscpp</depend>
+  <depend>rosmsg</depend>
+  <depend>libopencv-dev</depend>
+  <depend>cv_bridge</depend>
+  <depend>image_transport</depend>
+  <depend>tf</depend>
+  <depend>actionlib_msgs</depend>
+  <depend>control_msgs</depend>
+  <depend>diagnostic_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>map_msgs</depend>
+  <depend>nav_msgs</depend>
+  <depend>pcl_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>shape_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>tf2_geometry_msgs</depend>
+  <depend>tf2_msgs</depend>
+  <depend>tf2_sensor_msgs</depend>
+  <depend>trajectory_msgs</depend>
+  <depend>visualization_msgs</depend>
+  <depend>rosconsole</depend>
+  <depend>brics_actuator</depend>
+  <depend>roslib</depend>
 </package>
-
-


### PR DESCRIPTION
This PR is to simplify the CMakeLists.txt and package.xml according to the [catkin/CMakeLists.txt](http://wiki.ros.org/catkin/CMakeLists.txt) and the [catkin/package.xml](http://wiki.ros.org/catkin/package.xml).
* No ROS codename and `link_directories` are needed.

@Coppelia @fferri  

